### PR TITLE
`basePath` option to store relative paths in cache

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
 var crypto = require('crypto');
+var path = require('path');
 var through = require('through2');
 
 var GLOBAL_CACHE = {};
 
 // look for changes by mtime
-function processFileByModifiedTime(stream, firstPass, file, cache) {
+function processFileByModifiedTime(stream, firstPass, basePath, file, cache) {
   var newTime = file.stat && file.stat.mtime;
-  var oldTime = cache[file.path];
+  var filePath = basePath ? path.relative(basePath, file.path) : file.path;
+  var oldTime = cache[filePath];
 
-  cache[file.path] = newTime.getTime();
+  cache[filePath] = newTime.getTime();
 
   if ((!oldTime && firstPass) || (oldTime && oldTime !== newTime.getTime())) {
     stream.push(file);
@@ -16,7 +18,7 @@ function processFileByModifiedTime(stream, firstPass, file, cache) {
 }
 
 // look for changes by sha1 hash
-function processFileBySha1Hash(stream, firstPass, file, cache) {
+function processFileBySha1Hash(stream, firstPass, basePath, file, cache) {
   // null cannot be hashed
   if (file.contents === null) {
     // if element is really a file, something weird happened, but it's safer
@@ -27,9 +29,10 @@ function processFileBySha1Hash(stream, firstPass, file, cache) {
     }
   } else {
     var newHash = crypto.createHash('sha1').update(file.contents).digest('hex');
-    var currentHash = cache[file.path];
+    var filePath = basePath ? path.relative(basePath, file.path) : file.path;
+    var currentHash = cache[filePath];
 
-    cache[file.path] = newHash;
+    cache[filePath] = newHash;
 
     if ((!currentHash && firstPass) || (currentHash && currentHash !== newHash)) {
       stream.push(file);
@@ -53,11 +56,12 @@ module.exports = function (options) {
       processFile = processFileBySha1Hash;
   }
 
+  var basePath = options.basePath || "";
   var cache = options.cache || GLOBAL_CACHE;
   var firstPass = options.firstPass === true;
 
   return through.obj(function (file, encoding, callback) {
-    processFile(this, firstPass, file, cache);
+    processFile(this, firstPass, basePath, file, cache);
     callback();
   });
 }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function (options) {
       processFile = processFileBySha1Hash;
   }
 
-  var basePath = options.basePath || "";
+  var basePath = options.basePath || undefined;
   var cache = options.cache || GLOBAL_CACHE;
   var firstPass = options.firstPass === true;
 

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,6 @@ gulp.task('default', function () {
 
   Makes `gulp-changed-in-place` pass through all files once on the first run.
 
-
 #### `cache`
 * `Object` 
 * Default = as global variable
@@ -51,7 +50,7 @@ gulp.task('default', function () {
   Object of {key: value} for all the files. Value will be hash or modification time, depending on the option for how difference is determined. 
 
 #### `howToDetermineDifference`
-* "hash" || "modification-time"
+* `"hash" || "modification-time"`
 * Default = `hash`
 
   Selects how it is determined if a file has been changed.
@@ -64,13 +63,15 @@ gulp.task('default', function () {
 .pipe(changedInPlace( howToDetermineDifference: "modification-time"))
 ```
 
+#### `basePath`
+* `string`
+* Default = `undefined`
+
+  Save to cache file paths relative to `basePath`.
 
 # Version History
 
 [Change log](changelog.md)
-
-
-
 
 # License
 

--- a/test.js
+++ b/test.js
@@ -52,9 +52,9 @@ describe('gulp-changed-in-place', function () {
         .pipe(es.map(function (file, callback) {
           // imitate gulp.dest without actualy writing files
           // @see https://github.com/gulpjs/vinyl-fs/blob/master/lib/prepareWrite.js#L24
-          var rargetBase = path.resolve(file.cwd, './build')
-          var targetPath = path.resolve(rargetBase, file.relative);
-          file.base = rargetBase;
+          var targetBase = path.resolve(file.cwd, './build')
+          var targetPath = path.resolve(targetBase, file.relative);
+          file.base = targetBase;
           file.path = targetPath;
           callback(null, file);
         }))
@@ -163,9 +163,9 @@ describe('gulp-changed-in-place', function () {
         .pipe(es.map(function (file, callback) {
           // imitate gulp.dest without actualy writing files
           // @see https://github.com/gulpjs/vinyl-fs/blob/master/lib/prepareWrite.js#L24
-          var rargetBase = path.resolve(file.cwd, './build')
-          var targetPath = path.resolve(rargetBase, file.relative);
-          file.base = rargetBase;
+          var targetBase = path.resolve(file.cwd, './build')
+          var targetPath = path.resolve(targetBase, file.relative);
+          file.base = targetBase;
           file.path = targetPath;
           callback(null, file);
         }))

--- a/test.js
+++ b/test.js
@@ -52,7 +52,7 @@ describe('gulp-changed-in-place', function () {
         .pipe(es.map(function (file, callback) {
           // imitate gulp.dest without actualy writing files
           // @see https://github.com/gulpjs/vinyl-fs/blob/master/lib/prepareWrite.js#L24
-          var targetBase = path.resolve(file.cwd, './build')
+          var targetBase = path.resolve(file.cwd, './build');
           var targetPath = path.resolve(targetBase, file.relative);
           file.base = targetBase;
           file.path = targetPath;
@@ -127,10 +127,8 @@ describe('gulp-changed-in-place', function () {
 
       var timeNow = Date.now() / 1000;  // https://nodejs.org/docs/latest/api/fs.html#fs_fs_utimes_path_atime_mtime_callback
 
-      var theDate = new Date();
-      var currentYear = new Date().getFullYear();
-      var yesterYear = currentYear - 1;
-      var timeThen = new Date().setFullYear(yesterYear);
+      var timeThen = new Date();
+      timeThen.setFullYear(timeThen.getFullYear() - 1);
 
       var fileBTime = fs.statSync(fileB).mtime;
       fs.utimesSync(fileA, timeNow, timeNow);
@@ -163,7 +161,7 @@ describe('gulp-changed-in-place', function () {
         .pipe(es.map(function (file, callback) {
           // imitate gulp.dest without actualy writing files
           // @see https://github.com/gulpjs/vinyl-fs/blob/master/lib/prepareWrite.js#L24
-          var targetBase = path.resolve(file.cwd, './build')
+          var targetBase = path.resolve(file.cwd, './build');
           var targetPath = path.resolve(targetBase, file.relative);
           file.base = targetBase;
           file.path = targetPath;

--- a/test.js
+++ b/test.js
@@ -68,6 +68,26 @@ describe('gulp-changed-in-place', function () {
           done();
         }));
     });
+
+    it('should use paths relative to `basePath`', function (done) {
+      var shas = {};
+      var basePath = __dirname;
+
+      gulp.src('fixture/*')
+        .pipe(changedInPlace({
+          firstPass: true,
+          basePath: basePath,
+          cache: shas
+        }))
+        .pipe(concatStream(function (files) {
+
+          files.map(function (file) {
+            assert.equal(true, shas.hasOwnProperty(path.relative(basePath, file.path)), 'file path should be relative');
+          });
+
+          done();
+        }));
+    });
   });
 
   describe('when comparing by file modification time: ', function () {
@@ -154,6 +174,27 @@ describe('gulp-changed-in-place', function () {
 
           files.map(function (file) {
             assert.equal(undefined, times[file.path], 'path of changed file should not be in cache');
+          });
+
+          done();
+        }));
+    });
+
+    it('should use paths relative to `basePath`', function (done) {
+      var times = {};
+      var basePath = __dirname;
+
+      gulp.src('fixture/*')
+        .pipe(changedInPlace({
+          firstPass: true,
+          basePath: basePath,
+          cache: times,
+          howToDetermineDifference: 'modification-time'
+        }))
+        .pipe(concatStream(function (files) {
+
+          files.map(function (file) {
+            assert.equal(true, times.hasOwnProperty(path.relative(basePath, file.path)), 'file path should be relative');
           });
 
           done();


### PR DESCRIPTION
As @RehanSaeed noted in #7 it may be useful to persist cache in VCS, but file paths saved to cache are absolute and may differ on different machines.

`basePath` option allows to save to cache relative file paths.

Also I added `.editorconfig` to share such editor settings like number of spaces in indentation.